### PR TITLE
#9 - ADR-0009: Redis Streams as Default Message Transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Component-based architecture**: API (PHP), OAuth server (PHP, co-deployed with API), Workers (PHP), Frontend (SvelteKit + Bits UI), Ingress (Traefik)
 - **Data store**: PostgreSQL (with materialised views, JSONB, PgBouncer)
-- **Messaging**: Apache Pulsar for async job dispatch and event streaming
+- **Messaging**: Redis Streams (via Symfony Messenger) for async job dispatch and event streaming
 - **Auth**: League OAuth2 Server with JWT, 2FA (TOTP), social login (Google, GitHub)
 - **API**: RESTful, JSON, versioned via URI (`/v1/`), RFC 7807 errors, OpenAPI 3.1
 - **Deployment**: Kubernetes + Helm (umbrella chart with sub-charts per component)

--- a/docs/adr/0001-high-level-architecture.md
+++ b/docs/adr/0001-high-level-architecture.md
@@ -50,7 +50,7 @@ Adopt **Option 3: Component-Based Architecture**. The skeleton is designed to be
 │                         │                               │
 │                         ▼                               │
 │                  ┌──────────────┐                        │
-│                  │   Pulsar     │                        │
+│                  │   Redis      │                        │
 │                  │   (Streams)  │                        │
 │                  └──────┬───────┘                        │
 │                         │                               │
@@ -70,7 +70,7 @@ Adopt **Option 3: Component-Based Architecture**. The skeleton is designed to be
 | **Frontend** | Svelte + Bits UI | User-facing SPA — auth flows, dashboard shell |
 | **API Gateway** | Symfony 7 (PHP) | RESTful API, request validation, auth middleware, command dispatch |
 | **OAuth 2.0 Server** | Symfony 7 (PHP) | User registration, login, password reset, 2FA, social login (Google, GitHub) |
-| **Message Streams** | Apache Pulsar | Async command/event transport between API and workers |
+| **Message Streams** | Redis Streams | Async command/event transport between API and workers via Symfony Messenger |
 | **Workers** | Symfony 7 (PHP) | Process async jobs via Symfony Messenger — email, provisioning, background tasks |
 | **Mercure Hub** | Mercure (Go) | Real-time push to browsers via SSE — notifications, inbox updates |
 | **Data Store** | PostgreSQL + PgBouncer | Primary OLTP store, materialised views for read-heavy queries, connection pooling |
@@ -88,7 +88,7 @@ Both applications share a common **Domain** and **Infrastructure** library layer
 1. **Frontend (SvelteKit server) → API**: HTTPS/REST with JWT bearer tokens. Browser sessions managed via httpOnly cookies — the browser never directly handles JWTs.
 2. **Frontend (browser) → OAuth Server**: Redirect-based flows for login, registration, and social auth (Authorization Code + PKCE). Token exchange handled by SvelteKit server routes.
 3. **API → OAuth Server**: Shared PHP interface within the same pod (not internal HTTP). The interface is designed so that swapping to HTTP later requires only a new implementation, not changes to calling code.
-4. **API → Workers**: Pulsar message streams via Symfony Messenger with a custom Pulsar transport (fire-and-forget commands, request-reply where needed).
+4. **API → Workers**: Redis Streams via Symfony Messenger's built-in Redis transport (fire-and-forget commands, request-reply where needed).
 5. **Workers → Data Store**: PostgreSQL connection via PgBouncer (transaction mode). Workers acquire a connection at job start and release it at job end.
 6. **API → Data Store**: PostgreSQL connection via PgBouncer for synchronous reads.
 
@@ -126,10 +126,9 @@ Components discover each other via **Kubernetes cluster DNS** (e.g. `api.default
 │   operational complexity disproportionate to the skeleton's     │
 │   threat model. Noted as a production hardening enhancement.    │
 │                                                                 │
-│   Pulsar MUST be configured with authentication and             │
-│   namespace-level authorisation, even within the cluster.       │
-│   A compromised component must not be able to inject messages   │
-│   into arbitrary topics. See ADR-0004.                          │
+│   Redis is configured with password authentication (AUTH)       │
+│   and optionally ACLs to restrict per-component access          │
+│   (API can publish, workers can consume). See ADR-0009.         │
 └────────────────────────┬────────────────────────────────────────┘
                          │
                          ▼
@@ -153,35 +152,35 @@ Components discover each other via **Kubernetes cluster DNS** (e.g. `api.default
 | Traefik | Frontend (SvelteKit) | HTTP | None (cluster-internal) | Yes |
 | Traefik | API / Auth | HTTP | None (cluster-internal) | Yes |
 | Frontend | API / Auth | HTTP | None (cluster-internal) | Yes |
-| API | Pulsar | HTTP/Binary | Pulsar token auth | Yes |
+| API | Redis | TCP | Redis AUTH password | Yes |
 | API | PostgreSQL (via PgBouncer) | TCP | DB credentials | Yes |
-| Workers | Pulsar | HTTP/Binary | Pulsar token auth | Yes |
+| Workers | Redis | TCP | Redis AUTH password | Yes |
 | Workers | PostgreSQL (via PgBouncer) | TCP | DB credentials | Yes |
 | API | Mercure Hub | HTTP | JWT publisher token | Yes |
 | Frontend | Mercure Hub | SSE | JWT subscriber token | Yes |
 | Frontend | PostgreSQL | — | — | **No** |
+| Frontend | Redis | — | — | **No** |
 | Workers | Traefik | — | — | **No** |
-| Pulsar | PostgreSQL | — | — | **No** |
 
 **NetworkPolicies**: the skeleton should document intended network restrictions (the "No" rows above) even if Kubernetes NetworkPolicies are not enforced in the initial release. Adopters deploying to production should implement NetworkPolicies to enforce this matrix.
 
 ### Secrets Management
 
-All component secrets (database credentials, JWT signing keys, Pulsar auth tokens, social login API keys) are managed via **Kubernetes Secrets**, injected as environment variables or mounted as files.
+All component secrets (database credentials, JWT signing keys, Redis password, social login API keys) are managed via **Kubernetes Secrets**, injected as environment variables or mounted as files.
 
 - **JWT signing keys** are mounted as files (not environment variables) to avoid accidental logging. See ADR-0003 for key management details.
 - **Database credentials** are separated per component with least-privilege access. See ADR-0002.
-- **Pulsar auth tokens** are per-component. See ADR-0004.
+- **Redis password** is shared across components that access Redis (API, workers). See ADR-0009.
 - Secret management strategy (Sealed Secrets, SOPS, or External Secrets Operator) is defined in ADR-0007.
 
 ### Local Development Resource Requirements
 
-Running the full stack locally (API, Auth, Workers, Pulsar standalone, PostgreSQL, PgBouncer, Traefik, Frontend, Mercure Hub) requires:
+Running the full stack locally (API, Auth, Workers, Redis, PostgreSQL, PgBouncer, Traefik, Frontend, Mercure Hub) requires:
 
-- **Minimum**: 8 GB RAM allocated to Docker, 4 CPU cores
-- **Recommended**: 16 GB RAM, 6 CPU cores
+- **Minimum**: 4 GB RAM allocated to Docker, 2 CPU cores
+- **Recommended**: 8 GB RAM, 4 CPU cores
 
-A **minimal profile** is provided via Helm values that runs only essential components (API, Auth, PostgreSQL, Frontend) without Pulsar or workers, for frontend-focused development or machines with limited resources.
+A **minimal profile** is provided via Helm values that runs only essential components (API, Auth, PostgreSQL, Redis, Frontend) without workers, for frontend-focused development or machines with limited resources.
 
 ## Consequences
 
@@ -198,15 +197,16 @@ A **minimal profile** is provided via Helm values that runs only essential compo
 
 ### Risks
 - Over-engineering for small teams who may not need independent scaling initially
-- Pulsar operational complexity may deter adoption (mitigated by providing good Helm defaults)
+- Redis single-node bottleneck under extreme load (mitigated by Sentinel/Cluster upgrade path and Pulsar escape hatch — see ADR-0009)
 - PHP worker processes need careful lifecycle management (memory leaks, signal handling)
 
 ## Related Decisions
 
 - [ADR-0002](0002-use-postgresql.md) — PostgreSQL as primary data store
 - [ADR-0003](0003-oauth2-server-with-php.md) — OAuth 2.0 server implementation
-- [ADR-0004](0004-message-streaming-with-pulsar.md) — Async messaging with Pulsar
+- [ADR-0004](0004-message-streaming-with-pulsar.md) — Original Pulsar decision (superseded by ADR-0009)
 - [ADR-0005](0005-svelte-frontend.md) — Front-end technology choice
 - [ADR-0006](0006-restful-api-first.md) — API style decision
 - [ADR-0007](0007-container-orchestration-with-kubernetes.md) — Deployment infrastructure
 - [ADR-0008](0008-use-symfony-framework.md) — Symfony 7 as the PHP framework
+- [ADR-0009](0009-redis-streams-for-messaging.md) — Redis Streams as default message transport

--- a/docs/adr/0002-use-postgresql.md
+++ b/docs/adr/0002-use-postgresql.md
@@ -57,8 +57,8 @@ Use **Doctrine Migrations** for versioned schema management:
 
 ### Materialised View Refresh Strategy
 
-Use **event-driven refresh triggered via Pulsar** (Symfony Messenger), not scheduled refresh:
-- When a write operation completes, the API publishes a domain event to Pulsar (e.g. `tenant.usage.updated`).
+Use **event-driven refresh triggered via Symfony Messenger** (Redis Streams transport, see ADR-0009), not scheduled refresh:
+- When a write operation completes, the API publishes a domain event via Symfony Messenger (e.g. `tenant.usage.updated`).
 - A dedicated worker subscribes to these events and calls `REFRESH MATERIALIZED VIEW CONCURRENTLY <view>`.
 - `CONCURRENTLY` is required — it allows reads during refresh (requires a unique index on the view).
 - **Debounced refresh**: the worker batches events and refreshes at most once per configurable interval (e.g. 30 seconds) to avoid excessive refresh under high write loads.
@@ -141,5 +141,5 @@ Credentials stored as Kubernetes Secrets, injected as environment variables. See
 ## Related Decisions
 
 - [ADR-0001](0001-high-level-architecture.md) — High-level architecture (PostgreSQL as data store component, trust boundaries)
-- [ADR-0004](0004-message-streaming-with-pulsar.md) — Materialised view refresh triggered via Pulsar events (Symfony Messenger)
+- [ADR-0009](0009-redis-streams-for-messaging.md) — Materialised view refresh triggered via Redis Streams (Symfony Messenger)
 - [ADR-0008](0008-use-symfony-framework.md) — Symfony 7 with Doctrine DBAL integration

--- a/docs/adr/0003-oauth2-server-with-php.md
+++ b/docs/adr/0003-oauth2-server-with-php.md
@@ -186,6 +186,6 @@ The skeleton supports the **Client Credentials** grant for service-to-service au
 ## Related Decisions
 
 - [ADR-0001](0001-high-level-architecture.md) — OAuth server as a component in the architecture
-- [ADR-0004](0004-message-streaming-with-pulsar.md) — Email verification dispatched via Pulsar (Symfony Messenger)
+- [ADR-0009](0009-redis-streams-for-messaging.md) — Email verification dispatched via message transport (Redis Streams)
 - [ADR-0005](0005-svelte-frontend.md) — SvelteKit BFF handles token exchange and httpOnly cookie management
 - [ADR-0008](0008-use-symfony-framework.md) — Symfony 7 framework, Security component integration

--- a/docs/adr/0004-message-streaming-with-pulsar.md
+++ b/docs/adr/0004-message-streaming-with-pulsar.md
@@ -1,7 +1,7 @@
 # ADR-0004: Message Streaming with Apache Pulsar
 
 **Date**: 2026-04-04
-**Status**: Accepted
+**Status**: Superseded by [ADR-0009](0009-redis-streams-for-messaging.md)
 **Deciders**: Project Architect (IC7), Project Owner, Principal Infrastructure (IC6), Principal PHP (IC6)
 
 ## Context

--- a/docs/adr/0006-restful-api-first.md
+++ b/docs/adr/0006-restful-api-first.md
@@ -11,7 +11,7 @@ The SaaS skeleton needs an API layer that the front-end and potentially third-pa
 - Expose CRUD operations for core resources (users, tenants, configuration)
 - Support authentication via JWT bearer tokens
 - Be well-documented and easy for adopters to extend
-- Handle both synchronous reads and async command dispatch (via Pulsar)
+- Handle both synchronous reads and async command dispatch (via Symfony Messenger)
 
 The project owner is open to either REST or GraphQL.
 

--- a/docs/adr/0007-container-orchestration-with-kubernetes.md
+++ b/docs/adr/0007-container-orchestration-with-kubernetes.md
@@ -8,7 +8,7 @@
 
 The SaaS skeleton is designed as a set of independently deployable components (ADR-0001). We need:
 
-- Container orchestration for all components (API, workers, front-end, Pulsar, PostgreSQL, Mercure)
+- Container orchestration for all components (API, workers, front-end, Redis, PostgreSQL, Mercure)
 - Declarative, versioned deployment configuration
 - Service discovery and internal networking
 - Scaling policies (particularly for workers)
@@ -42,7 +42,7 @@ Use **Kubernetes with Helm** for all environments, including local development v
 
 - **Single paradigm**: one deployment model from development through production eliminates environment drift.
 - **Helm charts**: provide a clean packaging model — adopters `helm install` and get a working stack.
-- **Ecosystem**: Pulsar, PostgreSQL (Bitnami), Traefik, and Mercure all have official or well-maintained Helm charts.
+- **Ecosystem**: Redis, PostgreSQL (Bitnami), Traefik, and Mercure all have official or well-maintained Helm charts.
 - **Cloud portability**: Kubernetes runs on every major cloud provider and on-premises.
 
 ### Helm Chart Structure
@@ -50,7 +50,7 @@ Use **Kubernetes with Helm** for all environments, including local development v
 ```
 helm/
 ├── skelly-saas/                    # Umbrella chart
-│   ├── Chart.yaml                  # Dependencies: api, frontend, workers, ingress, mercure
+│   ├── Chart.yaml                  # Dependencies: api, frontend, workers, ingress, mercure, redis
 │   ├── values.yaml                 # Global defaults + per-component overrides
 │   ├── values-dev.yaml             # Development overrides (resource reductions, debug flags)
 │   ├── values-prod.yaml            # Production overrides (replicas, resource limits)
@@ -69,7 +69,7 @@ helm/
 │       ├── workers/                # PHP worker fleet
 │       ├── mercure/                # Mercure hub (SSE push)
 │       └── ingress/                # Traefik IngressRoute CRDs
-├── pulsar/                         # Referenced via Chart.yaml dependency (official chart)
+├── redis/                          # Referenced via Chart.yaml dependency (Bitnami)
 └── postgresql/                     # Referenced via Chart.yaml dependency (Bitnami)
 ```
 
@@ -120,7 +120,7 @@ k3d's bundled Traefik is disabled — the skeleton deploys its own Traefik via H
 | Workers | 250m | 500m | 256Mi | 512Mi | 1 | 3+ (HPA) |
 | Mercure Hub | 100m | 250m | 64Mi | 128Mi | 1 | 2 |
 | Traefik | 100m | 250m | 128Mi | 256Mi | 1 | 2 |
-| Pulsar (standalone) | 500m | 1000m | 1Gi | 2Gi | 1 | N/A |
+| Redis | 50m | 100m | 64Mi | 128Mi | 1 | 1 (Sentinel/Cluster) |
 | PostgreSQL | 250m | 500m | 256Mi | 512Mi | 1 | 1 (managed) |
 | PgBouncer | 50m | 100m | 32Mi | 64Mi | 1 | 2 |
 
@@ -186,12 +186,11 @@ Default-deny NetworkPolicies with explicit allow rules, **enabled by default** i
 | Source | Destination | Allowed |
 |--------|------------|---------|
 | Traefik (ingress) | API, Frontend, Mercure | ✅ |
-| API | PostgreSQL (PgBouncer), Pulsar, Mercure | ✅ |
-| Workers | PostgreSQL (PgBouncer), Pulsar | ✅ |
+| API | PostgreSQL (PgBouncer), Redis, Mercure | ✅ |
+| Workers | PostgreSQL (PgBouncer), Redis | ✅ |
 | Frontend | API (via Traefik) | ✅ |
-| Frontend | PostgreSQL, Pulsar | ❌ |
+| Frontend | PostgreSQL, Redis | ❌ |
 | Workers | Traefik | ❌ |
-| Pulsar | PostgreSQL | ❌ |
 
 This enforces the network communication matrix defined in ADR-0001.
 
@@ -232,7 +231,7 @@ All pods run as non-root, with no privilege escalation, no host networking, and 
 Included as an optional Helm chart dependency (disabled by default, enabled via `monitoring.enabled: true`):
 
 - **Prometheus** (via kube-prometheus-stack) for metrics
-- **Grafana** for dashboards — includes pre-built dashboards for API latency, worker throughput, Pulsar metrics
+- **Grafana** for dashboards — includes pre-built dashboards for API latency, worker throughput, Redis metrics
 - **Loki** for log aggregation
 
 ### Developer Experience: Makefile
@@ -261,11 +260,11 @@ scan-images:          ## Scan Docker images for vulnerabilities
 - Umbrella chart allows full-stack or per-component deployment
 - Tilt provides fast live-reload for development
 - Sealed Secrets provide git-based secret management without external dependencies
-- External dependencies (Pulsar, PostgreSQL) managed via official charts
+- External dependencies (Redis, PostgreSQL) managed via official Bitnami charts
 
 ### Negative
 - Kubernetes learning curve is steep for teams without prior experience
-- Local development requires running a Kubernetes cluster (~8 GB RAM minimum)
+- Local development requires running a Kubernetes cluster (~4 GB RAM minimum)
 - Helm template debugging can be frustrating
 - NetworkPolicies and RBAC add Helm template complexity
 
@@ -278,6 +277,6 @@ scan-images:          ## Scan Docker images for vulnerabilities
 ## Related Decisions
 
 - [ADR-0001](0001-high-level-architecture.md) — Component topology, trust boundaries, network communication matrix
-- [ADR-0004](0004-message-streaming-with-pulsar.md) — Pulsar Helm chart as a dependency, standalone/cluster profiles
+- [ADR-0009](0009-redis-streams-for-messaging.md) — Redis Helm chart as a dependency (replaces Pulsar)
 - [ADR-0005](0005-svelte-frontend.md) — Frontend Docker image (adapter-node, multi-stage build)
 - [ADR-0008](0008-use-symfony-framework.md) — Mercure hub added to chart, Symfony container builds

--- a/docs/adr/0008-use-symfony-framework.md
+++ b/docs/adr/0008-use-symfony-framework.md
@@ -12,7 +12,7 @@ The confirmed feature scope includes:
 
 - RESTful API with OpenAPI documentation (ADR-0006)
 - OAuth 2.0 server with registration, login, 2FA, social login (ADR-0003)
-- Async worker processing via Pulsar (ADR-0004)
+- Async worker processing via Redis Streams (ADR-0009)
 - In-app inbox / messaging system
 - WebSocket / real-time push notifications
 - Multi-channel notifications (email, in-app, push)
@@ -34,7 +34,7 @@ Full-featured framework with extensive ecosystem (Horizon, Echo, Reverb, Sanctum
 
 ### Option 3: Symfony 7 (Selected)
 Component-based full-stack framework with 50+ decoupled components.
-- **Pros**: Components are independently usable and PSR-compliant, excellent DI with autowiring, Messenger component provides transport abstraction (custom Pulsar transport is ~1 class), native Mercure integration for real-time push, Notifier for multi-channel notifications, RateLimiter component, Serializer, Validator, Console, Mailer — all battle-tested. Doctrine DBAL/Migrations integrate natively. Strong typing and explicit configuration.
+- **Pros**: Components are independently usable and PSR-compliant, excellent DI with autowiring, Messenger component provides transport abstraction (built-in Redis transport, Pulsar available as upgrade), native Mercure integration for real-time push, Notifier for multi-channel notifications, RateLimiter component, Serializer, Validator, Console, Mailer — all battle-tested. Doctrine DBAL/Migrations integrate natively. Strong typing and explicit configuration.
 - **Cons**: Steeper initial learning curve than Slim, heavier bootstrap than a micro-framework, configuration can be verbose, compiled container adds a build step.
 
 ## Decision
@@ -45,7 +45,7 @@ Use **Symfony 7** as the PHP framework for both the API and Auth applications.
 
 The deciding factors, in order of weight:
 
-1. **Messenger + Pulsar transport**: Symfony Messenger provides the exact transport abstraction we planned to build manually (see ADR-0004 review). Writing a Pulsar transport is a single class implementing `TransportInterface`. Routing, retry, serialisation, middleware, and handler dispatch come free. This alone saves significant development and maintenance effort.
+1. **Messenger + built-in Redis transport**: Symfony Messenger provides transport abstraction with a first-party Redis Streams transport (`symfony/redis-messenger`). No custom transport code needed. Routing, retry, serialisation, middleware, and handler dispatch come free. Upgrading to Pulsar later is a DSN change + adding a custom transport class — no application code changes. See ADR-0009.
 
 2. **Mercure for real-time push**: The inbox and push notification requirements need server-to-browser real-time delivery. Mercure is a purpose-built protocol with a lightweight Go hub server. Symfony has native integration — publishing an update is a single service call. This is simpler and more scalable than raw WebSockets for notification/inbox use cases, works behind load balancers without sticky sessions, and doesn't require a separate PHP long-running process.
 
@@ -78,7 +78,7 @@ src/
 │   └── Service/            # Domain services
 ├── Infrastructure/         # Shared infrastructure
 │   ├── Database/           # Doctrine DBAL repositories, migrations
-│   ├── Messaging/          # Pulsar transport, message handlers
+│   ├── Messaging/          # Redis transport config, message handlers
 │   ├── Notification/       # Notifier channels (inbox, push)
 │   └── Security/           # JWT validation, password hashing
 └── Worker/                 # Worker entry point
@@ -94,7 +94,7 @@ Traefik routes `/auth/*` to the Auth kernel and `/api/*` to the API kernel. Both
 |-----------|---------|----------|
 | **HttpKernel** | Request handling, controller dispatch | Slim router |
 | **DependencyInjection** | Autowired, compiled DI container | Manual PHP-DI setup |
-| **Messenger** | Async message dispatch + Pulsar transport | Custom MessageProducer/Consumer interfaces |
+| **Messenger** | Async message dispatch + Redis transport (built-in) | Custom MessageProducer/Consumer interfaces |
 | **Mercure** | Real-time push to browsers (SSE) | Custom WebSocket server |
 | **Notifier** | Multi-channel notifications | Custom notification system |
 | **RateLimiter** | Per-endpoint, per-account throttling | Custom rate limiting middleware |
@@ -115,7 +115,7 @@ Traefik routes `/auth/*` to the Auth kernel and `/api/*` to the API kernel. Both
 
 ### Positive
 - Batteries-included: inbox, push notifications, async messaging, rate limiting, validation all have framework-level support
-- Messenger + custom Pulsar transport eliminates the need for a hand-rolled messaging abstraction
+- Messenger + built-in Redis transport eliminates the need for any custom messaging code
 - Mercure gives real-time push without a custom WebSocket server or PHP long-running process
 - Doctrine DBAL integrates natively — no adapter layer
 - Adopters can add Symfony components incrementally as their requirements grow
@@ -138,7 +138,7 @@ Traefik routes `/auth/*` to the Auth kernel and `/api/*` to the API kernel. Both
 - [ADR-0001](0001-high-level-architecture.md) — component architecture that this framework serves
 - [ADR-0002](0002-use-postgresql.md) — Doctrine DBAL integration
 - [ADR-0003](0003-oauth2-server-with-php.md) — League OAuth2 Server integrated via Symfony Security authenticators
-- [ADR-0004](0004-message-streaming-with-pulsar.md) — Pulsar accessed via Symfony Messenger custom transport
+- [ADR-0009](0009-redis-streams-for-messaging.md) — Redis Streams via Symfony Messenger built-in transport
 - [ADR-0006](0006-restful-api-first.md) — API structure built on Symfony HttpKernel + controllers
 - [ADR-0007](0007-container-orchestration-with-kubernetes.md) — Mercure hub added to Helm chart
 - Supersedes the Slim Framework recommendation made in the Principal PHP review on issue #3

--- a/docs/adr/0009-redis-streams-for-messaging.md
+++ b/docs/adr/0009-redis-streams-for-messaging.md
@@ -1,0 +1,179 @@
+# ADR-0009: Redis Streams as Default Message Transport
+
+**Date**: 2026-04-05
+**Status**: Accepted
+**Deciders**: Project Architect (IC7), Project Owner
+
+## Context
+
+ADR-0004 selected Apache Pulsar as the message streaming platform. After further analysis, the operational complexity of Pulsar is disproportionate to the skeleton's needs, particularly for smaller teams building prototype SaaS applications.
+
+### Pulsar's Operational Footprint
+
+- **Development**: standalone mode requires ~500m CPU, 1 GiB RAM, 10 GiB persistence — just for messaging.
+- **Production**: minimum 7+ pods (3 ZooKeeper, 3 BookKeeper, 1+ Broker), each with its own resource requirements.
+- **PHP integration**: requires a custom `TransportInterface` implementation for Symfony Messenger, using Pulsar's HTTP REST API (the PHP client ecosystem is immature).
+- **Learning curve**: teams unfamiliar with Pulsar face a steep operational learning curve (ZooKeeper quorum, BookKeeper ledger management, topic/namespace administration).
+
+### Redis Is Already in the Stack
+
+Redis is already a required infrastructure dependency for:
+- **Rate limiting counters** (ADR-0003, ADR-0006): Symfony RateLimiter needs a persistent store for multi-pod consistency.
+- **Symfony cache**: application-level caching.
+
+Adding Redis Streams as the message transport consolidates infrastructure rather than introducing a new system.
+
+### Symfony Messenger Makes Transport Swapping Trivial
+
+Symfony Messenger (ADR-0008) abstracts the transport layer entirely. Swapping from Redis to Pulsar is a single-line DSN change in `messenger.yaml`:
+
+```yaml
+# Redis (skeleton default)
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: 'redis://redis:6379/messages'
+
+# Pulsar (upgrade path)
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: 'pulsar://pulsar:6650/persistent/public/default/messages'
+```
+
+No application code, message classes, handlers, middleware, or routing changes are required. Retry logic, failure transport (DLQ), serialisation, and handler dispatch are all transport-agnostic.
+
+### Skeleton Async Use Cases
+
+The skeleton's async workloads are all covered by Redis Streams:
+- Email verification dispatch
+- Password reset emails
+- Tenant provisioning
+- Materialised view refresh (ADR-0002)
+- Multi-channel notifications (Symfony Notifier via Messenger)
+
+None of these require Pulsar-grade features (replay, tiered storage, broker-level multi-tenancy).
+
+## Options Considered
+
+### Option 1: Keep Apache Pulsar (ADR-0004)
+Retain Pulsar as the default transport.
+- **Pros**: replayable message streams, built-in multi-tenancy, tiered storage, dual queue/topic semantics.
+- **Cons**: 7+ pods in production, ~1 GiB RAM just for dev standalone mode, requires custom Symfony Messenger transport class, ZooKeeper/BookKeeper operational complexity, immature PHP ecosystem, steep learning curve for adopters.
+
+### Option 2: Redis Streams (Selected)
+Use Redis Streams via Symfony Messenger's built-in Redis transport.
+- **Pros**: single process (~64 MiB RAM), already required for rate limiting and cache, zero custom transport code (first-party `symfony/redis-messenger`), consumer groups for competing workers, message acknowledgement via `XACK`, familiar technology, trivial to operate.
+- **Cons**: no message replay by default, no built-in broker-level multi-tenancy, persistence is RDB/AOF-based (configurable but not replicated by default), single-node bottleneck without Sentinel/Cluster.
+
+### Option 3: RabbitMQ
+Mature message broker with excellent PHP support.
+- **Pros**: very mature, excellent `php-amqplib` client, wide adoption, supports delayed messages via plugins, well-understood operational model.
+- **Cons**: not already in the stack (adds a new infrastructure dependency), messages are consumed-and-gone by default (no replay), clustering can be fragile, Erlang runtime adds operational overhead compared to Redis.
+
+## Decision
+
+Use **Redis Streams** as the default message transport via Symfony Messenger's built-in Redis transport (`symfony/redis-messenger`).
+
+### Rationale
+
+- **No new infrastructure**: Redis is already required for rate limiting and cache. Using it for messaging means one fewer system to deploy, monitor, and operate.
+- **No custom code**: the Redis transport is maintained by the Symfony core team. The Pulsar approach required a custom `TransportInterface` implementation — Redis requires zero custom transport code.
+- **Right-sized for the skeleton**: Redis Streams covers all skeleton async use cases. Pulsar's enterprise features (replay, tiered storage, multi-tenancy) are not needed for prototype SaaS applications.
+- **Familiar**: the project owner and most PHP teams are already familiar with Redis.
+- **Trivial upgrade path**: when a team outgrows Redis, swapping to Pulsar (or RabbitMQ, or Amazon SQS) is a DSN change + adding the relevant transport package. No application code changes.
+
+### Redis Streams Capabilities
+
+Redis Streams (via `XADD`, `XREADGROUP`, `XACK`) provide:
+
+| Capability | How |
+|-----------|-----|
+| Persistent message delivery | Messages stored in the stream until explicitly trimmed |
+| Competing consumers | Consumer groups — multiple workers share the workload |
+| Message acknowledgement | `XACK` — unacknowledged messages are re-delivered after timeout |
+| Fan-out | Multiple consumer groups on the same stream |
+| Delayed messages | Handled by Symfony Messenger's delay stamp (transport-agnostic) |
+| Dead letter queue | Handled by Symfony Messenger's failure transport (transport-agnostic) |
+| Retry with backoff | Handled by Symfony Messenger's retry configuration (transport-agnostic) |
+
+### Pulsar as the Documented Upgrade Path
+
+Pulsar is not removed from the project's vocabulary — it is repositioned as the upgrade path for teams that need:
+
+- **Message replay**: audit trails, event sourcing, reprocessing after bug fixes
+- **Broker-level multi-tenancy**: namespace isolation per tenant at the messaging layer
+- **Tiered storage**: cost-effective long-term message retention
+- **Extreme throughput**: >100k messages/second sustained
+
+The upgrade process:
+1. Install the custom Pulsar transport package (to be published as a Composer package)
+2. Deploy Pulsar via its official Helm chart
+3. Change the DSN in `messenger.yaml`
+4. No application code changes
+
+### Redis Deployment
+
+**Development** (default):
+- Single Redis instance via Bitnami Redis Helm chart
+- Minimal resources: ~50m CPU, 64 MiB RAM, 1 GiB persistence
+- Serves messaging, rate limiting, and cache from the same instance
+
+**Production** (documented upgrade paths):
+- **Redis Sentinel**: automatic failover with master/replica topology. Recommended first step for HA.
+- **Redis Cluster**: horizontal scaling for high-throughput workloads.
+- **Managed Redis**: AWS ElastiCache, GCP Memorystore, Azure Cache for Redis.
+
+### Redis Configuration for Messaging
+
+```yaml
+# Redis persistence (ensure messages survive restarts)
+appendonly yes
+appendfsync everysec
+
+# Stream memory management
+maxmemory-policy noeviction    # Never evict stream data — let Messenger handle trimming
+```
+
+Symfony Messenger handles stream trimming — old messages are removed after successful processing. No manual `XTRIM` configuration needed.
+
+### Redis Authentication
+
+Redis is configured with password authentication (AUTH), injected via Kubernetes Secret. The DSN includes the password:
+
+```
+redis://:<password>@redis:6379/messages
+```
+
+For production, Redis ACLs can restrict per-component access (API can publish, workers can consume). This replaces the Pulsar namespace-level authorisation described in ADR-0001.
+
+## Consequences
+
+### Positive
+- Drastically reduced infrastructure footprint — one Redis instance replaces Pulsar's 7+ pod production topology
+- No custom transport code — `symfony/redis-messenger` is first-party, maintained by the Symfony core team
+- Redis is already in the stack for rate limiting and cache — no new infrastructure dependency
+- Familiar technology for most PHP teams
+- Local development resource requirements reduced (~64 MiB vs ~1 GiB for Pulsar standalone)
+- Trivial upgrade path to Pulsar, RabbitMQ, or SQS via DSN change
+
+### Negative
+- No message replay by default — teams needing audit trail replay must upgrade to Pulsar or implement application-level event sourcing
+- No built-in broker-level multi-tenancy — tenant isolation at the messaging layer requires key prefixes (application-level), not broker namespaces
+- Redis persistence is best-effort (RDB/AOF) — a crash between AOF fsyncs can lose the most recent messages (mitigated by `appendfsync everysec`, which limits loss to ~1 second of data)
+
+### Risks
+- Redis single-node bottleneck for high-volume workloads — mitigated by Sentinel/Cluster upgrade path and Pulsar escape hatch
+- Redis memory pressure if streams grow unbounded — mitigated by Symfony Messenger's stream trimming and `maxmemory-policy noeviction`
+- Teams may defer the Pulsar upgrade too long and hit Redis limits — mitigated by documenting clear "when to upgrade" criteria in the skeleton's production readiness guide
+
+## Related Decisions
+
+- [ADR-0001](0001-high-level-architecture.md) — Redis replaces Pulsar in the component architecture
+- [ADR-0002](0002-use-postgresql.md) — Materialised view refresh via Redis Streams (Symfony Messenger)
+- [ADR-0003](0003-oauth2-server-with-php.md) — Redis also serves rate limiting counters for auth endpoints
+- [ADR-0004](0004-message-streaming-with-pulsar.md) — Superseded by this ADR
+- [ADR-0007](0007-container-orchestration-with-kubernetes.md) — Bitnami Redis Helm chart replaces Pulsar chart
+- [ADR-0008](0008-use-symfony-framework.md) — Symfony Messenger with built-in Redis transport

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,8 +27,9 @@ ADRs are numbered sequentially: `NNNN-short-title.md` (e.g. `0001-use-postgresql
 | [0001](0001-high-level-architecture.md) | High-Level Architecture | Accepted |
 | [0002](0002-use-postgresql.md) | Use PostgreSQL for Primary Data Store | Accepted |
 | [0003](0003-oauth2-server-with-php.md) | OAuth 2.0 Server with PHP | Accepted |
-| [0004](0004-message-streaming-with-pulsar.md) | Message Streaming with Apache Pulsar | Accepted |
+| [0004](0004-message-streaming-with-pulsar.md) | Message Streaming with Apache Pulsar | Superseded by ADR-0009 |
 | [0005](0005-svelte-frontend.md) | Svelte with Bits UI for Frontend | Accepted |
 | [0006](0006-restful-api-first.md) | RESTful API as Primary Interface | Accepted |
 | [0007](0007-container-orchestration-with-kubernetes.md) | Container Orchestration with Kubernetes and Helm | Accepted |
 | [0008](0008-use-symfony-framework.md) | Use Symfony 7 as the PHP Framework | Accepted |
+| [0009](0009-redis-streams-for-messaging.md) | Redis Streams as Default Message Transport | Accepted |


### PR DESCRIPTION
## Summary

- **New ADR-0009**: Redis Streams as the default async message transport via Symfony Messenger's built-in `symfony/redis-messenger`, replacing Apache Pulsar (ADR-0004)
- **Pulsar repositioned** as a documented upgrade path — transport swap is a DSN change with zero application code changes
- **Cross-reference updates** across ADRs 0001, 0002, 0003, 0006, 0007, 0008, README index, and CLAUDE.md
- **Local dev resource requirements** reduced from 8 GB to 4 GB RAM minimum

## Key decisions

- Redis serves triple duty: messaging (Streams), rate limiting (RateLimiter store), and cache — replacing Pulsar's 7+ pod production topology with a single process
- Symfony Messenger's transport abstraction means all message classes, handlers, middleware, and routing remain identical regardless of transport
- ADR-0004 preserved as a superseded record for decision history

## Test plan

- [ ] Verify all ADR cross-reference links resolve correctly
- [ ] Verify no orphaned Pulsar references remain in active ADRs (only in superseded ADR-0004 and as upgrade path context in ADR-0009)
- [ ] Security review of Redis AUTH/ACL configuration in ADR-0009
- [ ] Infrastructure review of Redis Helm chart integration in ADR-0007

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)